### PR TITLE
Add Go CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: Go CI
+
+on:
+  push:
+    branches: ["main", "codex/**"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+
+      - name: Verify formatting
+        run: |
+          fmt_out=$(gofmt -l .)
+          if [ -n "$fmt_out" ]; then
+            echo "The following files need gofmt:" >&2
+            echo "$fmt_out" >&2
+            exit 1
+          fi
+
+      - name: Go build
+        run: go build ./...
+
+      - name: Go test
+        run: go test -cover ./...


### PR DESCRIPTION
## Intent
- Add continuous integration for Go formatting, build, and test coverage as requested in issue #2.

## Changes
- Introduce `.github/workflows/ci.yml` to run gofmt diff checks, `go build`, and `go test -cover` on push and PR events.
- Enable module caching via `actions/setup-go@v5` to speed up runs.

## Testing
- `gofmt -l .`
- `go build ./...`
- `go test -cover ./...`

Closes #2
