### PR TITLE
Implement git branch history retrieval

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,3 +1,149 @@
 package git
 
-// Package git will provide git command execution and parsing utilities.
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Runner interface {
+	Run(ctx context.Context, args ...string) ([]byte, error)
+}
+
+type CommandRunner struct{}
+
+func (CommandRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	return cmd.CombinedOutput()
+}
+
+type Client struct {
+	runner Runner
+}
+
+func NewClient(r Runner) *Client {
+	if r == nil {
+		r = CommandRunner{}
+	}
+	return &Client{runner: r}
+}
+
+func (c *Client) CurrentBranch(ctx context.Context) (string, error) {
+	out, err := c.run(ctx, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	branch := strings.TrimSpace(out)
+	if branch == "" {
+		return "", errors.New("git: empty branch name")
+	}
+	return branch, nil
+}
+
+func (c *Client) ReflogBranchVisits(ctx context.Context) ([]string, error) {
+	out, err := c.run(ctx, "reflog", "--format=%gs")
+	if err != nil {
+		return nil, err
+	}
+	subjects := strings.Split(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n")
+	var visits []string
+	for _, subject := range subjects {
+		if subject == "" {
+			continue
+		}
+		if branch := extractBranchFromReflogSubject(subject); branch != "" {
+			visits = append(visits, branch)
+		}
+	}
+	return visits, nil
+}
+
+func (c *Client) LocalBranches(ctx context.Context) ([]string, error) {
+	out, err := c.run(ctx, "for-each-ref", "--sort=-committerdate", "--format=%(refname:short)", "refs/heads")
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n")
+	branches := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		branches = append(branches, line)
+	}
+	return branches, nil
+}
+
+func (c *Client) run(ctx context.Context, args ...string) (string, error) {
+	out, err := c.runner.Run(ctx, args...)
+	output := string(out)
+	if err != nil {
+		trimmed := strings.TrimSpace(output)
+		if trimmed != "" {
+			return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, trimmed)
+		}
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return output, nil
+}
+
+func extractBranchFromReflogSubject(subject string) string {
+	trimmed := strings.TrimSpace(subject)
+	if trimmed == "" {
+		return ""
+	}
+
+	lower := strings.ToLower(trimmed)
+
+	switch {
+	case strings.HasPrefix(lower, "checkout:"):
+		return branchFromSuffix(trimmed)
+	case strings.HasPrefix(lower, "switch branch:"):
+		return branchFromSuffix(trimmed)
+	case strings.HasPrefix(lower, "switch to branch"):
+		return branchFromQuoted(trimmed)
+	case strings.HasPrefix(lower, "reset: moving to"):
+		return branchFromSuffix(trimmed)
+	}
+
+	return ""
+}
+
+func branchFromSuffix(line string) string {
+	idx := strings.LastIndex(strings.ToLower(line), " to ")
+	if idx == -1 {
+		return ""
+	}
+
+	candidate := strings.TrimSpace(line[idx+4:])
+	candidate = strings.Trim(candidate, "'\"")
+
+	if candidate == "" || strings.HasPrefix(candidate, "HEAD") {
+		return ""
+	}
+	if space := strings.IndexAny(candidate, " \t"); space != -1 {
+		candidate = candidate[:space]
+	}
+	return candidate
+}
+
+func branchFromQuoted(line string) string {
+	start := strings.Index(line, "'")
+	if start == -1 {
+		return ""
+	}
+	rest := line[start+1:]
+	end := strings.Index(rest, "'")
+	if end == -1 {
+		return ""
+	}
+	candidate := rest[:end]
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" || strings.HasPrefix(candidate, "HEAD") {
+		return ""
+	}
+	return candidate
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,143 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type stubRunner struct {
+	responses map[string]stubResponse
+}
+
+type stubResponse struct {
+	output string
+	err    error
+}
+
+func (s stubRunner) Run(_ context.Context, args ...string) ([]byte, error) {
+	key := strings.Join(args, "\x00")
+	resp, ok := s.responses[key]
+	if !ok {
+		return nil, fmt.Errorf("unexpected command: %s", strings.Join(args, " "))
+	}
+	return []byte(resp.output), resp.err
+}
+
+func TestClientCurrentBranch(t *testing.T) {
+	runner := stubRunner{responses: map[string]stubResponse{
+		strings.Join([]string{"rev-parse", "--abbrev-ref", "HEAD"}, "\x00"): {output: "main\n"},
+	}}
+
+	client := NewClient(runner)
+	branch, err := client.CurrentBranch(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentBranch error: %v", err)
+	}
+	if branch != "main" {
+		t.Fatalf("expected main, got %q", branch)
+	}
+}
+
+func TestClientReflogBranchVisits(t *testing.T) {
+	runner := stubRunner{responses: map[string]stubResponse{
+		strings.Join([]string{"reflog", "--format=%gs"}, "\x00"): {output: strings.Join([]string{
+			"checkout: moving from feature/foo to main",
+			"switch branch: from main to feature/bar",
+			"switch to branch 'bugfix'",
+			"checkout: moving from bugfix to HEAD^",
+			"merge feature/bar",
+		}, "\n")},
+	}}
+
+	client := NewClient(runner)
+	branches, err := client.ReflogBranchVisits(context.Background())
+	if err != nil {
+		t.Fatalf("ReflogBranchVisits error: %v", err)
+	}
+
+	expected := []string{"main", "feature/bar", "bugfix"}
+	if len(branches) != len(expected) {
+		t.Fatalf("expected %d branches, got %d (%v)", len(expected), len(branches), branches)
+	}
+	for i, want := range expected {
+		if branches[i] != want {
+			t.Fatalf("index %d: want %q, got %q", i, want, branches[i])
+		}
+	}
+}
+
+func TestClientReflogBranchVisitsEmpty(t *testing.T) {
+	runner := stubRunner{responses: map[string]stubResponse{
+		strings.Join([]string{"reflog", "--format=%gs"}, "\x00"): {output: ""},
+	}}
+
+	client := NewClient(runner)
+	branches, err := client.ReflogBranchVisits(context.Background())
+	if err != nil {
+		t.Fatalf("ReflogBranchVisits error: %v", err)
+	}
+	if len(branches) != 0 {
+		t.Fatalf("expected no branches, got %v", branches)
+	}
+}
+
+func TestClientLocalBranches(t *testing.T) {
+	runner := stubRunner{responses: map[string]stubResponse{
+		strings.Join([]string{"for-each-ref", "--sort=-committerdate", "--format=%(refname:short)", "refs/heads"}, "\x00"): {output: "main\nfeature/foo\n\n"},
+	}}
+
+	client := NewClient(runner)
+	branches, err := client.LocalBranches(context.Background())
+	if err != nil {
+		t.Fatalf("LocalBranches error: %v", err)
+	}
+	expected := []string{"main", "feature/foo"}
+	if len(branches) != len(expected) {
+		t.Fatalf("expected %d branches, got %d", len(expected), len(branches))
+	}
+	for i, want := range expected {
+		if branches[i] != want {
+			t.Fatalf("index %d: want %q, got %q", i, want, branches[i])
+		}
+	}
+}
+
+func TestClientRunErrorPropagation(t *testing.T) {
+	stubErr := errors.New("boom")
+	runner := stubRunner{responses: map[string]stubResponse{
+		strings.Join([]string{"rev-parse", "--abbrev-ref", "HEAD"}, "\x00"): {output: "fatal: not a git repository\n", err: stubErr},
+	}}
+
+	client := NewClient(runner)
+	_, err := client.CurrentBranch(context.Background())
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "fatal: not a git repository") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestExtractBranchFromReflogSubject(t *testing.T) {
+	cases := map[string]string{
+		"checkout: moving from main to feature/foo": "feature/foo",
+		"checkout: moving to feature/bar":           "feature/bar",
+		"switch branch: from main to bugfix":        "bugfix",
+		"switch to branch 'topic/test'":             "topic/test",
+		"reset: moving to release":                  "release",
+		"checkout: moving from main to HEAD^":       "",
+		"unrelated message":                         "",
+		"checkout: moving from main to origin/main": "origin/main",
+		"switch to branch 'HEAD~1'":                 "",
+	}
+
+	for input, want := range cases {
+		got := extractBranchFromReflogSubject(input)
+		if got != want {
+			t.Errorf("input %q: want %q, got %q", input, want, got)
+		}
+	}
+}

--- a/internal/navigator/navigator.go
+++ b/internal/navigator/navigator.go
@@ -1,3 +1,93 @@
 package navigator
 
-// Package navigator manages branch history and selection workflows.
+import (
+	"context"
+	"fmt"
+)
+
+type Git interface {
+	CurrentBranch(ctx context.Context) (string, error)
+	ReflogBranchVisits(ctx context.Context) ([]string, error)
+	LocalBranches(ctx context.Context) ([]string, error)
+}
+
+type Navigator struct {
+	git Git
+}
+
+func NewNavigator(g Git) (*Navigator, error) {
+	if g == nil {
+		return nil, fmt.Errorf("navigator: git client is required")
+	}
+	return &Navigator{git: g}, nil
+}
+
+func (n *Navigator) RecentBranches(ctx context.Context, limit int) ([]string, error) {
+	if limit <= 0 {
+		return []string{}, nil
+	}
+
+	current, err := n.git.CurrentBranch(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	locals, err := n.git.LocalBranches(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	localSet := make(map[string]struct{}, len(locals))
+	for _, branch := range locals {
+		localSet[branch] = struct{}{}
+	}
+
+	history, err := n.git.ReflogBranchVisits(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]string, 0, limit)
+	seen := make(map[string]struct{}, limit)
+
+	appendCandidate := func(branch string) {
+		if branch == "" {
+			return
+		}
+		if branch == current {
+			return
+		}
+		if _, ok := seen[branch]; ok {
+			return
+		}
+		seen[branch] = struct{}{}
+		result = append(result, branch)
+	}
+
+	for _, branch := range history {
+		if len(result) >= limit {
+			break
+		}
+		if _, ok := localSet[branch]; !ok {
+			continue
+		}
+		appendCandidate(branch)
+	}
+
+	if len(result) >= limit {
+		return result[:limit], nil
+	}
+
+	for _, branch := range locals {
+		if len(result) >= limit {
+			break
+		}
+		appendCandidate(branch)
+	}
+
+	if len(result) > limit {
+		result = result[:limit]
+	}
+
+	return result, nil
+}

--- a/internal/navigator/navigator_test.go
+++ b/internal/navigator/navigator_test.go
@@ -1,0 +1,118 @@
+package navigator
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type stubGit struct {
+	current    string
+	history    []string
+	locals     []string
+	currentErr error
+	historyErr error
+	localsErr  error
+}
+
+func (s *stubGit) CurrentBranch(context.Context) (string, error) {
+	if s.currentErr != nil {
+		return "", s.currentErr
+	}
+	return s.current, nil
+}
+
+func (s *stubGit) ReflogBranchVisits(context.Context) ([]string, error) {
+	if s.historyErr != nil {
+		return nil, s.historyErr
+	}
+	return append([]string(nil), s.history...), nil
+}
+
+func (s *stubGit) LocalBranches(context.Context) ([]string, error) {
+	if s.localsErr != nil {
+		return nil, s.localsErr
+	}
+	return append([]string(nil), s.locals...), nil
+}
+
+func TestNewNavigatorValidatesGit(t *testing.T) {
+	if _, err := NewNavigator(nil); err == nil {
+		t.Fatalf("expected error when Git is nil")
+	}
+}
+
+func TestRecentBranchesUsesHistoryFirst(t *testing.T) {
+	gitStub := &stubGit{
+		current: "main",
+		locals:  []string{"feature/b", "feature/a", "main"},
+		history: []string{"feature/b", "main", "feature/a", "feature/b"},
+	}
+
+	navigator, err := NewNavigator(gitStub)
+	if err != nil {
+		t.Fatalf("NewNavigator error: %v", err)
+	}
+
+	got, err := navigator.RecentBranches(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("RecentBranches error: %v", err)
+	}
+
+	want := []string{"feature/b", "feature/a"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestRecentBranchesFallsBackToLocalBranches(t *testing.T) {
+	gitStub := &stubGit{
+		current: "main",
+		locals:  []string{"feature/a", "feature/b", "main"},
+		history: []string{"origin/main"},
+	}
+
+	navigator, err := NewNavigator(gitStub)
+	if err != nil {
+		t.Fatalf("NewNavigator error: %v", err)
+	}
+
+	got, err := navigator.RecentBranches(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("RecentBranches error: %v", err)
+	}
+
+	want := []string{"feature/a", "feature/b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestRecentBranchesLimitZero(t *testing.T) {
+	gitStub := &stubGit{current: "main"}
+	navigator, err := NewNavigator(gitStub)
+	if err != nil {
+		t.Fatalf("NewNavigator error: %v", err)
+	}
+
+	got, err := navigator.RecentBranches(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("RecentBranches error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}
+
+func TestRecentBranchesPropagatesErrors(t *testing.T) {
+	currentErr := errors.New("current branch error")
+	gitStub := &stubGit{currentErr: currentErr}
+	navigator, err := NewNavigator(gitStub)
+	if err != nil {
+		t.Fatalf("NewNavigator error: %v", err)
+	}
+	if _, err := navigator.RecentBranches(context.Background(), 5); !errors.Is(err, currentErr) {
+		t.Fatalf("expected error %v, got %v", currentErr, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add git client helpers to parse reflog and list local branches
- provide navigator that merges history with fallback list and dedupes current branch
- cover parsing and selection logic with table-driven tests

## Testing
- go test ./...

Closes #3