### PR TITLE
Git履歴からブランチ候補を取得

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# Build cache
+.cache/

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,3 +1,179 @@
 package git
 
-// Package git will provide git command execution and parsing utilities.
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Runner executes git commands.
+type Runner interface {
+	Run(ctx context.Context, args ...string) (string, error)
+}
+
+// CLI executes git commands using the local git binary.
+type CLI struct{}
+
+// NewCLI constructs a CLI Runner.
+func NewCLI() *CLI {
+	return &CLI{}
+}
+
+// Run invokes the git binary with the provided arguments.
+func (c *CLI) Run(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		if stderr.Len() > 0 {
+			return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+		}
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// Client provides higher-level git helpers used by the navigator.
+type Client struct {
+	runner Runner
+}
+
+// NewClient constructs a Client using the supplied Runner.
+func NewClient(r Runner) *Client {
+	return &Client{runner: r}
+}
+
+// NewDefaultClient constructs a Client backed by the CLI Runner.
+func NewDefaultClient() *Client {
+	return NewClient(NewCLI())
+}
+
+// CurrentBranch returns the current branch name.
+func (c *Client) CurrentBranch(ctx context.Context) (string, error) {
+	if c == nil || c.runner == nil {
+		return "", errors.New("git client is not configured")
+	}
+	out, err := c.runner.Run(ctx, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+// ReflogBranchMoves returns branch names discovered in the HEAD reflog.
+func (c *Client) ReflogBranchMoves(ctx context.Context) ([]string, error) {
+	if c == nil || c.runner == nil {
+		return nil, errors.New("git client is not configured")
+	}
+	out, err := c.runner.Run(ctx, "reflog", "--format=%gs")
+	if err != nil {
+		return nil, err
+	}
+	return parseReflogSubjects(out), nil
+}
+
+// BranchesByCommitDate returns local branches ordered by most recent commit date.
+func (c *Client) BranchesByCommitDate(ctx context.Context) ([]string, error) {
+	if c == nil || c.runner == nil {
+		return nil, errors.New("git client is not configured")
+	}
+	out, err := c.runner.Run(ctx, "for-each-ref", "--format=%(refname:short)", "--sort=-committerdate", "refs/heads")
+	if err != nil {
+		return nil, err
+	}
+	return splitAndFilter(out), nil
+}
+
+// BranchExists reports whether the provided local branch exists.
+func (c *Client) BranchExists(ctx context.Context, branch string) (bool, error) {
+	if c == nil || c.runner == nil {
+		return false, errors.New("git client is not configured")
+	}
+	if strings.TrimSpace(branch) == "" {
+		return false, nil
+	}
+	_, err := c.runner.Run(ctx, "show-ref", "--verify", "--quiet", fmt.Sprintf("refs/heads/%s", branch))
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func parseReflogSubjects(output string) []string {
+	lines := splitAndFilter(output)
+	branches := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if branch, ok := extractBranchFromSubject(line); ok {
+			branches = append(branches, branch)
+		}
+	}
+	return branches
+}
+
+func splitAndFilter(s string) []string {
+	raw := strings.Split(strings.TrimSpace(s), "\n")
+	out := make([]string, 0, len(raw))
+	for _, line := range raw {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+func extractBranchFromSubject(subject string) (string, bool) {
+	if subject == "" {
+		return "", false
+	}
+
+	const (
+		prefixMoveFrom  = "checkout: moving from "
+		prefixMoveTo    = "checkout: moving to "
+		prefixSwitching = "checkout: switching to "
+	)
+
+	switch {
+	case strings.HasPrefix(subject, prefixMoveFrom):
+		rest := strings.TrimPrefix(subject, prefixMoveFrom)
+		idx := strings.LastIndex(rest, " to ")
+		if idx == -1 {
+			return "", false
+		}
+		branch := strings.TrimSpace(rest[idx+4:])
+		branch = strings.Trim(branch, "'\"")
+		if branch == "" {
+			return "", false
+		}
+		return branch, true
+	case strings.HasPrefix(subject, prefixMoveTo):
+		branch := strings.TrimSpace(strings.TrimPrefix(subject, prefixMoveTo))
+		branch = strings.Trim(branch, "'\"")
+		if branch == "" {
+			return "", false
+		}
+		return branch, true
+	case strings.HasPrefix(subject, prefixSwitching):
+		branch := strings.TrimSpace(strings.TrimPrefix(subject, prefixSwitching))
+		branch = strings.Trim(branch, "'\"")
+		if branch == "" {
+			return "", false
+		}
+		return branch, true
+	default:
+		return "", false
+	}
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,73 @@
+package git
+
+import "testing"
+
+func TestExtractBranchFromSubject(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		subject string
+		branch  string
+		ok      bool
+	}{
+		"move-from": {
+			subject: "checkout: moving from main to feature/test",
+			branch:  "feature/test",
+			ok:      true,
+		},
+		"switching": {
+			subject: "checkout: switching to 'bugfix/issue-42'",
+			branch:  "bugfix/issue-42",
+			ok:      true,
+		},
+		"moving-to": {
+			subject: "checkout: moving to release",
+			branch:  "release",
+			ok:      true,
+		},
+		"empty": {
+			subject: "",
+			branch:  "",
+			ok:      false,
+		},
+		"unsupported": {
+			subject: "commit: add feature",
+			branch:  "",
+			ok:      false,
+		},
+		"missing-destination": {
+			subject: "checkout: moving from main",
+			branch:  "",
+			ok:      false,
+		},
+	}
+
+	for name, tc := range cases {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			branch, ok := extractBranchFromSubject(tc.subject)
+			if branch != tc.branch || ok != tc.ok {
+				t.Fatalf("extractBranchFromSubject(%q) = (%q, %v), want (%q, %v)", tc.subject, branch, ok, tc.branch, tc.ok)
+			}
+		})
+	}
+}
+
+func TestParseReflogSubjects(t *testing.T) {
+	t.Parallel()
+
+	input := "checkout: moving from main to feature/one\ncheckout: switching to 'feature/two'\ncommit: add something"
+	got := parseReflogSubjects(input)
+	want := []string{"feature/one", "feature/two"}
+
+	if len(got) != len(want) {
+		t.Fatalf("parseReflogSubjects returned %d entries, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("parseReflogSubjects[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/navigator/navigator.go
+++ b/internal/navigator/navigator.go
@@ -1,3 +1,98 @@
 package navigator
 
-// Package navigator manages branch history and selection workflows.
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// GitService describes the git functionality required by the navigator.
+type GitService interface {
+	CurrentBranch(ctx context.Context) (string, error)
+	ReflogBranchMoves(ctx context.Context) ([]string, error)
+	BranchesByCommitDate(ctx context.Context) ([]string, error)
+	BranchExists(ctx context.Context, branch string) (bool, error)
+}
+
+// Navigator coordinates branch retrieval using GitService.
+type Navigator struct {
+	git GitService
+}
+
+// New constructs a Navigator bound to the provided GitService.
+func New(git GitService) (*Navigator, error) {
+	if git == nil {
+		return nil, errors.New("git service is required")
+	}
+	return &Navigator{git: git}, nil
+}
+
+// RecentBranches returns up to limit recent branch names excluding the current branch, deduplicated.
+func (n *Navigator) RecentBranches(ctx context.Context, limit int) ([]string, error) {
+	if n == nil || n.git == nil {
+		return nil, errors.New("navigator is not configured")
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	current, err := n.git.CurrentBranch(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]string, 0, limit)
+	seen := map[string]struct{}{current: struct{}{}}
+
+	reflogBranches, err := n.git.ReflogBranchMoves(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	results, err = n.appendBranches(ctx, results, reflogBranches, seen, limit)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) >= limit {
+		return results, nil
+	}
+
+	fallbackBranches, err := n.git.BranchesByCommitDate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	results, err = n.appendBranches(ctx, results, fallbackBranches, seen, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+func (n *Navigator) appendBranches(ctx context.Context, current []string, candidates []string, seen map[string]struct{}, limit int) ([]string, error) {
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+
+		exists, err := n.git.BranchExists(ctx, candidate)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			continue
+		}
+
+		seen[candidate] = struct{}{}
+		current = append(current, candidate)
+		if len(current) >= limit {
+			break
+		}
+	}
+	return current, nil
+}

--- a/internal/navigator/navigator_test.go
+++ b/internal/navigator/navigator_test.go
@@ -1,0 +1,159 @@
+package navigator
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type fakeGit struct {
+	current      string
+	reflog       []string
+	fallback     []string
+	exists       map[string]bool
+	errCurrent   error
+	errReflog    error
+	errFallback  error
+	errExists    error
+	existsErrFor string
+}
+
+func (f *fakeGit) CurrentBranch(ctx context.Context) (string, error) {
+	return f.current, f.errCurrent
+}
+
+func (f *fakeGit) ReflogBranchMoves(ctx context.Context) ([]string, error) {
+	if f.errReflog != nil {
+		return nil, f.errReflog
+	}
+	return append([]string(nil), f.reflog...), nil
+}
+
+func (f *fakeGit) BranchesByCommitDate(ctx context.Context) ([]string, error) {
+	if f.errFallback != nil {
+		return nil, f.errFallback
+	}
+	return append([]string(nil), f.fallback...), nil
+}
+
+func (f *fakeGit) BranchExists(ctx context.Context, branch string) (bool, error) {
+	if f.errExists != nil && (f.existsErrFor == "" || f.existsErrFor == branch) {
+		return false, f.errExists
+	}
+	if f.exists == nil {
+		return false, nil
+	}
+	return f.exists[branch], nil
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	if _, err := New(nil); err == nil {
+		t.Fatal("expected error when git service is nil")
+	}
+
+	nav, err := New(&fakeGit{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if nav == nil {
+		t.Fatal("expected non-nil navigator")
+	}
+}
+
+func TestNavigatorRecentBranches(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	errExists := errors.New("branch exists failure")
+
+	cases := map[string]struct {
+		limit   int
+		git     *fakeGit
+		want    []string
+		wantErr error
+	}{
+		"reflog-only": {
+			limit: 3,
+			git: &fakeGit{
+				current:  "main",
+				reflog:   []string{"feature/one", "main", "feature/two"},
+				fallback: []string{"main", "feature/three"},
+				exists: map[string]bool{
+					"feature/one":   true,
+					"feature/two":   true,
+					"feature/three": true,
+				},
+			},
+			want: []string{"feature/one", "feature/two", "feature/three"},
+		},
+		"fallback-needed": {
+			limit: 2,
+			git: &fakeGit{
+				current:  "main",
+				reflog:   []string{"origin/main", "feature/x"},
+				fallback: []string{"feature/y"},
+				exists: map[string]bool{
+					"feature/x": true,
+					"feature/y": true,
+				},
+			},
+			want: []string{"feature/x", "feature/y"},
+		},
+		"limit-zero": {
+			limit: 0,
+			git:   &fakeGit{current: "main"},
+			want:  nil,
+		},
+		"branch-exists-error": {
+			limit: 1,
+			git: &fakeGit{
+				current:      "main",
+				reflog:       []string{"feature/broken"},
+				exists:       map[string]bool{"feature/broken": true},
+				errExists:    errExists,
+				existsErrFor: "feature/broken",
+			},
+			wantErr: errExists,
+		},
+	}
+
+	for name, tc := range cases {
+		name := name
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			nav, err := New(tc.git)
+			if err != nil {
+				t.Fatalf("New returned error: %v", err)
+			}
+
+			got, err := nav.RecentBranches(ctx, tc.limit)
+			if tc.wantErr != nil {
+				if err == nil || !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("unexpected branches: got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNavigatorMissingConfiguration(t *testing.T) {
+	t.Parallel()
+
+	var nav *Navigator
+	if _, err := nav.RecentBranches(context.Background(), 5); err == nil {
+		t.Fatal("expected error when navigator is nil")
+	}
+}


### PR DESCRIPTION
## 概要
- gitコマンドを実行するClientとRunnerを実装
- リフログとコミット日のローカルブランチ一覧を統合するNavigatorを追加
- git出力パーサとNavigatorのテーブル駆動テストを追加し、ビルドキャッシュを無視

## テスト
- GOCACHE=/Users/s_kajiwara/Documents/private/branch-navigator/.cache/go-build go test ./...

Closes #3